### PR TITLE
Document all the options to built-in functions

### DIFF
--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -3,13 +3,6 @@ title: Functions
 description: Function annotations enable dynamically executing code from a message to format values, or retrieve environment information.
 ---
 
-<style>
-table :is(td, th) {
-  border: 1px solid black;
-  padding: 0.3em;
-}
-</style>
-
 When you write an annotation in your MessageFormat message, then underneath the
 hood, the formatter calls a function. These could either be built-in functions
 that aim to assist you in performing common i18n operations like formatting

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -3,6 +3,13 @@ title: Functions
 description: Function annotations enable dynamically executing code from a message to format values, or retrieve environment information.
 ---
 
+<style>
+table :is(td, th) {
+  border: 1px solid black;
+  padding: 0.3em;
+}
+</style>
+
 When you write an annotation in your MessageFormat message, then underneath the
 hood, the formatter calls a function. These could either be built-in functions
 that aim to assist you in performing common i18n operations like formatting
@@ -131,8 +138,7 @@ The formatted result when annotating `3.14` with `:integer` is `3`. Otherwise,
 #### Number formatting
 
 The `number` function has many different options to control formatting, some of
-which also work for `integer`. The full list is in
-[the specification](https://github.com/unicode-org/message-format-wg/blob/main/spec/registry.md#options-1).
+which also work for `integer`.
 The following example shows how some of the options work.
 
 <mf2-interactive>
@@ -206,6 +212,254 @@ many {{{$numDays} dne}}
 With this option, since "2" is not literally equal to any of the other keys, the
 `*` variant matches.
 
+#### Options
+
+The following table includes all the options that can be passed to `:number`,
+according to
+[the specification](https://github.com/unicode-org/message-format-wg/blob/main/spec/registry.md#options-1).
+A description of each option follows.
+
+| Option name      | Allowed values                                    | Default value | Used with `:integer`? |
+|------------------|---------------------------------------------------|---------------|-----------------------|
+|`select`          | `plural`, `ordinal`, `exact`                      | `plural`      | yes                   |
+|`compactDisplay`  | `short`, `long`                                   | `short`       | no                    |
+|`notation`        | `standard`, `scientific`, `engineering`, `compact`| `standard`    | no                    |
+|`numberingSystem` | a valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier) | Locale-dependent | yes |
+|`signDisplay`     | `auto`, `always`, `exceptZero`, `negative`, `never` | `auto`      | yes                   |
+|`style`           | `decimal`, `percent`                              | `decimal`     | yes                   |
+|`useGrouping`     | `auto`, `always`, `never`, `min2`                 | `auto`        | yes                   |
+|`minimumIntegerDigits` | Digit size option (see below)                | `1`           | yes                   |
+|`minimumFractionDigits`| Digit size option (see below)                | No default    | no                    |
+|`maximumFractionDigits`| Digit size option (see below)                | No default    | no                    |
+|`minimumSignificantDigits` | Digit size option (see below)            | No default    | no                    |
+|`maximumSignificantDigits` | Digit size option (see below)            | No defualt    | yes                   |
+
+All the same options can be passed to `:integer`, except where noted in the rightmost
+column of the table.
+
+Many of the options are similar to the [JavaScript `Intl.NumberFormat` API.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat)
+
+**The `select` option**
+
+The `select` option controls how selectors are matched against keys
+when an expression annotated with `:number` is used as a selector.
+When `plural` (the default value) is provided as the value of this option,
+matching uses CLDR plural rules for cardinal numbers.
+When `ordinal` is provided, values are matched based on CLDR plural rules
+for ordinal numbers.
+When `exact` is provided, values are matched based on their exact contents.
+
+Compare the following three examples:
+
+<mf2-interactive>
+
+```mf2
+.input {$num :number}
+.match $num
+one  {{one!}}
+*    {{many!}}
+```
+
+```json
+{ "num": 2 }
+```
+</mf2-interactive>
+
+<mf2-interactive>
+
+```mf2
+.input {$num :number select=ordinal}
+.match $num
+one  {{You are {$num}st}}
+two  {{You are {$num}nd}}
+few {{You are {$num}rd}}
+*    {{You are {$num}th}}
+```
+
+```json
+{ "num": 2 }
+```
+</mf2-interactive>
+
+<mf2-interactive>
+
+```mf2
+.input {$num :number select=exact}
+.match $num
+1 {{one!}}
+2 {{two!}}
+3 {{three!}}
+* {{other!}}
+```
+
+```json
+{ "num": 2 }
+```
+</mf2-interactive>
+
+**The `compactDisplay` option**
+
+The `compactDisplay` option only has meaning when combined with the `notation` option.
+The meaning is locale-dependent, but the following examples show how it works
+for the `en-US` locale:
+
+<mf2-interactive locale=en-US>
+
+```mf2
+short: {$num :number compactDisplay=short notation=compact}
+long: {$num :number compactDisplay=long notation=compact}
+```
+
+```json
+{ "num": 10001 }
+```
+</mf2-interactive>
+
+With this option, numbers are rounded to the nearest thousand,
+million, or billion, which is then either represented as
+`K`/`M`/`B` or spelled out.
+
+**The `notation` option**
+
+The `notation` option has the following effects, depending on its value:
+* `standard`: Plain number formatting.
+* `scientific`: Order of magnitude.
+* `engineering`: Return the exponent of ten when divisible by three.
+* `compact` Number is abbreviated as explained previously.
+
+<mf2-interactive locale=en-US>
+
+```mf2
+standard: {$num :number notation=standard}
+scientific: {$num :number notation=scientific}
+engineering: {$num :number notation=engineering}
+compact: {$num :number notation=compact}
+```
+
+```json
+{ "num": 3001 }
+```
+</mf2-interactive>
+
+**The `numberingSystem` option**
+
+The `numberingSystem` option specifies which numbering system to use
+for formatting the number. [The list of possible values](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+is specified by Unicode.
+
+<mf2-interactive>
+
+```mf2
+{$num :number numberingSystem=roman} or
+{$num :number numberingSystem=arab} or
+{$num :number numberingSystem=thai}
+```
+
+```json
+{ "num": 3001 }
+```
+</mf2-interactive>
+
+**The `signDisplay` option**
+
+The `signDisplay` option specifies how to format the sign of a number.
+The possible values are:
+
+* `auto`: Display the sign for negative numbers only.
+* `always`: Always display the sign.
+* `exceptZero`: Display the sign for any non-zero number.
+* `negative`: Display the sign for negative numbers, excluding negative zero.
+* `never`: Never display the sign.
+
+The following example shows how negative 0 is processed:
+
+<mf2-interactive>
+
+```mf2
+auto: {$num :number signDisplay=auto}
+always: {$num :number signDisplay=always}
+exceptZero: {$num :number signDisplay=exceptZero}
+negative: {$num :number signDisplay=negative}
+never: {$num :number signDisplay=never}
+```
+
+```json
+{ "num": -0 }
+```
+</mf2-interactive>
+
+**The `style` option**
+
+The `style` option specifies whether to format a number as a decimal
+or as a percentage.
+
+<mf2-interactive>
+
+```mf2
+decimal: {$num :number style=decimal}
+percent: {$num :number style=percent}
+```
+
+```json
+{ "num": 42 }
+```
+</mf2-interactive>
+
+Passing `percent` causes the formatted number to be the input
+number, multiplied by 100.
+
+**The `useGrouping` option**
+
+The `useGrouping` option controls whether to use grouping
+separators, such as thousands separators in the `en-US` locale.
+
+The possible values are:
+
+* `auto`: Display grouping separators based on locale.
+* `always`: Always display grouping separators.
+* `never`: Never display grouping separators.
+* `min2`: Display grouping separators only when there are at least
+2 digits in a group.
+
+(Note: a bug in the messageformat package prevents inclusion
+of an interactive example.)
+
+**Digit size options**
+
+The five remaining options all take a "digit size" option,
+which is a small integer value greater than or equal to zero,
+or a string that can be parsed as one.
+
+The options are:
+
+* `minimumIntegerDigits`: The minimum number of integer digits
+to use in formatting the number. The number will be left-padded
+with zeros as much as necessary.
+* `minimumFractionDigits`: The minimum number of fraction digits
+to use in formatting the number.
+* `maximumFractionDigits`: The maximum number of fraction digits
+to use in formatting the number.
+* `minimumSignificantDigits`: The minimum number of significant
+digits to use.
+* `maximumSignificantDigits`: The maximum number of significant
+digits to use.
+
+The following example combines all five options and shows
+how two different numbers are formatted:
+
+<mf2-interactive>
+
+```mf2
+first: {$num1 :number minimumIntegerDigits=2 minimumFractionDigits=3 maximumFractionDigits=5 minimumSignificantDigits=1 maximumSignificantDigits=5}
+second: {$num2 :number minimumIntegerDigits=2 minimumFractionDigits=3 maximumFractionDigits=5 minimumSignificantDigits=1 maximumSignificantDigits=5}
+```
+
+```json
+{ "num1": 3.1415927,
+  "num2": 42.01 }
+```
+</mf2-interactive>
+
 ### The `string` function
 
 The `string` function is both a selector and a formatter function. It works on
@@ -255,6 +509,10 @@ operand.
 The exact details of how to stringify an operand are implementation-dependent,
 as you can see in this example (in JavaScript, the default stringification
 behavior of objects is to print them as `[object Object]`).
+
+#### Options
+
+The `string` function has no options.
 
 ### The `date`, `time`, and `datetime` functions
 
@@ -337,6 +595,99 @@ Or: the time is {$date :time style=long}.
 ```
 
 </mf2-interactive>
+
+#### Options
+
+**Options for `:datetime`:**
+
+| Option name      | Allowed values                                    | Default value |
+|------------------|---------------------------------------------------|---------------|
+|`dateStyle`       | `full`, `long`, `medium`, `short`                 | `medium`      |
+|`timeStyle`       | `full`, `long`, `medium`, `short`                 | `short`       |
+| `weekday`        | `long`, `short`, `narrow`                         | none          |
+| `era`            | `long`, `short`, `narrow`                         | none          |
+| `year`           | `numeric`, `2-digit`                              | none          |
+| `month`          | `numeric`, `2-digit`, `long`, `short`, `narrow`   | none          |
+| `day`            | `numeric`, `2-digit`                              | none          |
+| `hour`           | `numeric`, `2-digit`                              | none          |
+| `minute`         | `numeric`, `2-digit`                              | none          |
+| `second`         | `numeric`, `2-digit`                              | none          |
+| `fractionalSecondDigits` | `1`, `2`, `3`                             | none          |
+| `hourCycle`      | `h11`, `h12`, `h23`, `h24`                        | locale-specific |
+| `timeZoneName`   | `long`, `short`, `shortOffset`, `longOffset`, `shortGeneric`, `longGeneric` | none |
+
+All the options other than `dateStyle` and `timeStyle` are called "field options".
+Field options do not have defaults, as they're intended to override locale-
+and implementation-dependent default values.
+
+Field options cannot be specified if either `dateStyle` or `timeStyle` (or both)
+is specified.
+
+**Options for `:date` and `:time`**
+
+The `:date` and `:time` functions only have one option: `style`.
+Like the `dateStyle` and `timeStyle` options to `:datetime`, its values
+can be `full`, `long`, `medium`, or `short`. For `:date`, the default
+is medium, and for `:time`, the default is `:short`.
+
+The names of these options are largely derived from the
+[JavaScript `Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions#description)
+and they can be expected to have the same meaning as in `Intl.DateTimeFormat`.
+
+**Style options**
+
+The meanings of the style options (`dateStyle`/`timeStyle`/`style`) are
+locale-dependent. The following interactive example can be used to see
+how these options work.
+
+<mf2-interactive>
+
+```mf2
+Short: {$date :datetime dateStyle=short timeStyle=short}.
+Medium: {$date :datetime dateStyle=medium timeStyle=medium}.
+Long: {$date :datetime dateStyle=long timeStyle=long}.
+Full: {$date :datetime dateStyle=full timeStyle=full}.
+```
+
+```json
+{ "date": "2024-10-25T14:05:06" }
+```
+
+</mf2-interactive>
+
+**Field options**
+
+The meanings of the `weekday`, `era`, `year`, `month`, `day`, `hour`, `minute`, `second`,
+`fractionalSecondDigits`, and `timeZoneName` options depend on
+the available representations for dates and times in the current locale.
+
+The `hourCycle` option specifies the timekeeping convention
+to use in formatting the time:
+
+* `h12`: Hour system using 1-12 (12-hour clock with midnight at 12:00 AM).
+* `h23`: Hour system using 0-23 (24-hour clock with midnight at 0:00).
+* `h11`: Hour system using 0-11 (12-hour clock with midnight at 0:00 AM).
+* `h24`: Hour system using 0-24 (24-hour click with midnight at 24:00).
+
+
+When field options are used, only the explicitly-specified fields
+are present in the output. In the following example, the formatted
+date only contains the year and weekday.
+
+<mf2-interactive>
+
+```mf2
+{$date :datetime weekday=long year=|2-digit|}.
+```
+
+```json
+{ "date": "2024-10-25T14:05:06" }
+```
+
+</mf2-interactive>
+
+It's up to the developer to use a combination of field options
+that makes sense for the desired locale.
 
 ## Custom functions
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -138,6 +138,11 @@
   @apply bg-gray-100 p-4 rounded font-mono text-base overflow-y-auto;
 }
 
+.markdown table td, .markdown table th {
+  border: 1px solid black;
+  padding: 0.3em;
+}
+
 .markdown mf2-interactive {
   @apply border rounded overflow-clip my-4;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -139,8 +139,7 @@
 }
 
 .markdown table td, .markdown table th {
-  border: 1px solid black;
-  padding: 0.3em;
+  @apply border border-gray-300 p-2;
 }
 
 .markdown mf2-interactive {


### PR DESCRIPTION
In the functions reference, add tables and examples for all of the options to built-in functions.