### PR TITLE
Spell the name as "MessageFormat 2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [messageformat.dev](https://messageformat.dev)
 
-A website for Message Format 2, a tool for localizing dynamic messages in
+A website for MessageFormat 2 (MF2), a tool for localizing dynamic messages in
 software projects, by Unicode.
 
 The website is maintained by Luca Casonato (@lucacasonato).

--- a/about.md
+++ b/about.md
@@ -5,16 +5,16 @@ sidebar:
   - about/
 ---
 
-This website is a third party website for Message Format 2, maintained by Luca
+This website is a third party website for MessageFormat 2, maintained by Luca
 Casonato.
 
 This website was developed by Luca Casonato. The content is maintained by Luca
 Casonato and Tim Chevalier.
 
 The playground and interactie code blocks format messages using the JavaScript
-implementation of Message Format 2, maintained by Eemeli Aro. Highlighting and
+implementation of MessageFormat 2, maintained by Eemeli Aro. Highlighting and
 other language features are powered by the
-[Message Format 2 Language Server](https://github.com/lucacasonato/mf2-tools),
+[MessageFormat 2 Language Server](https://github.com/lucacasonato/mf2-tools),
 maintained by Luca Casonato and Nicolò Ribaudo.
 
 ## License
@@ -26,7 +26,7 @@ code for this website is licensed under the
 
 ## Logo
 
-The Message Format logo was designed by Luca Casonato. It is licensed under the
+The MessageFormat logo was designed by Luca Casonato. It is licensed under the
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license.
 
 There are multiple versions of the logo - see the below table for the different

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,21 +3,21 @@ title: Quick Start
 description: Get started with the basics of MessageFormat 2.
 ---
 
-MessageFormat 2 is designed to enable localization of dynamic messages across
-different human languages. This page walks through the syntax of Message Format
-2 messages, giving an overview of what Message Format 2 is capable of.
+MessageFormat 2 (MF2) is designed to enable localization of dynamic messages across
+different human languages. This page walks through the syntax of MessageFormat
+2 messages, giving an overview of what MessageFormat 2 is capable of.
 
-To use Message Format 2 in a project, follow these set up guides:
+To use MessageFormat 2 in a project, follow these set up guides:
 
 - [JavaScript/Typescript](/docs/integration/js)
 - [Java](/docs/integration/java)
 - [C](/docs/integration/c)
 - [C++](/docs/integration/cpp)
 
-To set up your editor or IDE to work with Message Format 2, see the
+To set up your editor or IDE to work with MessageFormat 2, see the
 [editor setup](/docs/lsp) guide.
 
-You can also try out Message Format 2 in the online playground:
+You can also try out MessageFormat 2 in the online playground:
 
 <a href="/playground/" class="button mb-8">Try in Playground</a>
 
@@ -91,7 +91,7 @@ It is the {$today :datetime} today.
 
 </mf2-interactive>
 
-Message Format 2 has multiple built-in functions. These allow you, for example,
+MessageFormat 2 has multiple built-in functions. These allow you, for example,
 to format numbers in a locale appropriate way. See the
 [full list of built-in functions](/docs/reference/functions/).
 
@@ -183,14 +183,14 @@ It is {$now :datetime hourCycle=h12}
 
 </mf2-interactive>
 
-> There is no boolean literal in Message Format 2. Options with boolean values
+> There is no boolean literal in MessageFormat 2. Options with boolean values
 > usually use the text literals `true` and `false` to represent the two boolean
 > states.
 
 ### Quoted Text
 
 Text literals that need to contain spaces or special characters like `{` or `@`
-can be wrapped in `|`, the quote character in Message Format 2 syntax.
+can be wrapped in `|`, the quote character in MessageFormat 2 syntax.
 
 <mf2-interactive>
 
@@ -232,7 +232,7 @@ This is a star: {#star-icon /}
 
 </mf2-interactive>
 
-Message Format 2 does not define any specific markup tags. Instead, it is up to
+MessageFormat 2 does not define any specific markup tags. Instead, it is up to
 the application to define the tags that are used in messages. There is also no
 requirement that opening and closing tags must match, or that they are used in a
 hierarchical way.

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,11 +1,11 @@
 ---
-title: Why Message Format2?
-description: The background behind Message Format 2 - why it exists, and why Unicode is involved.
+title: Why MessageFormat 2?
+description: The background behind MessageFormat 2 - why it exists, and why Unicode is involved.
 ---
 
 TODO:
 
-- Why does Message Format 2 exist
+- Why does MessageFormat 2 exist
 - How does it compare to other systems like Fluent
 - MF2 is at unicode: it's the successor to MF1
 

--- a/index.tsx
+++ b/index.tsx
@@ -12,7 +12,7 @@ export default function IndexPage() {
           <Head />
           <section class="p-4 max-w-screen-lg mx-auto mt-2 md:mt-4 lg:mt-8 text-lg md:text-xl lg:text-2xl space-y-4">
             <AdParagraph>
-              MessageFormat 2 is a Unicode standard for localizable dynamic
+              MessageFormat 2 (MF2) is a Unicode standard for localizable dynamic
               message strings, designed to make it simple to create{" "}
               <b>natural sounding</b> localized messages.
             </AdParagraph>


### PR DESCRIPTION
In quite a few places, the name has an extraneous space, as in: "Message Format 2".

I've also here added "(MF2)" to the first mentions on the front page and the Quick Start page, as that abbreviation is also quite common.